### PR TITLE
feat: user-service AccountType update API 추가

### DIFF
--- a/src/main/java/com/lim1t/email/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/lim1t/email/global/config/RestTemplateConfig.java
@@ -1,0 +1,16 @@
+package com.lim1t.email.global.config;
+
+import org.springframework.cloud.client.loadbalancer.LoadBalanced;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    @LoadBalanced
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치 (필수)
- feat/User_Update_API

### 💡 작업동기 (선택) 
- 유저의 이메일 인증 상태를 최신화 시키기 위한 user-service API 연동

### 🔑 주요 변경사항 (필수)
- user-service 계정 타입 변경 API 추가 및 로드밸런싱 처리

### 관련 이슈 (선택)
- RestTemplate에서 Eureka의 로드밸런싱 처리를 하기 위해서는 RestTemplate 빈 등록시 @LoadBalanced 어노테이션을 추가해줘야 가능하다. 만약 어노테이션을 적용시키지 않는다면 "unknown protocol: lb" 에러가 발생한다.