### PR TITLE
smtp 포트설정이 되어있지 않은 버그 수정

### DIFF
--- a/src/main/java/com/lim1t/email/global/config/MailConfig.java
+++ b/src/main/java/com/lim1t/email/global/config/MailConfig.java
@@ -12,6 +12,8 @@ public class MailConfig {
 
     @Value("${spring.mail.host}")
     private String HOST;
+    @Value("${spring.mail.port}")
+    private int PORT;
     @Value("${spring.mail.username}")
     private String USERNAME;
     @Value("${spring.mail.password}")
@@ -22,6 +24,7 @@ public class MailConfig {
 
         JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
         mailSender.setHost(HOST);
+        mailSender.setPort(PORT);
         mailSender.setUsername(USERNAME);
         mailSender.setPassword(PASSWORD);
         Properties prop = new Properties();


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치 (필수)
- fix/sendmail_config

### 💡 작업동기 (선택) 
- stmp connection timeout 상태가 되는 버그 수정

### 🔑 주요 변경사항 (필수)
- SendMail smtp 기본포트 (25)  -> 587